### PR TITLE
 feat: observer hooks with inifinite scroll

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,10 @@ import GalleryList from "./components/gallery/GalleryList";
 import { useModal } from "./contexts/ModalProvider";
 import Carousel from "./components/carousel/Carousel";
 import GalleryItem from "./components/gallery/GalleryItem";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { PhotoAPI } from "./components/apis/photo";
 import { GetPhotoDTO, PhotoItem } from "./components/types/photo";
+import useIntersect from "./hooks/useIntersect";
 
 function App() {
   const { openModal } = useModal();
@@ -38,10 +39,17 @@ function App() {
     });
   };
 
-  useEffect(() => {
-    // todo: 무한 스크롤 구현
-    getRandomPhotos();
-  }, []);
+  const inifiniteRef = useIntersect({
+    onIntersect: async (entry, observer) => {
+      // 50 request / 1hour 를 조절하기 위해서 5회 요청 후에는 무한 스크롤 멈춤
+      if (galleryPhotos.length >= 30 * 5) {
+        // observer 와 target element 연결 해제
+        observer.unobserve(entry.target);
+      } else {
+        getRandomPhotos();
+      }
+    },
+  });
 
   return (
     <Container>
@@ -49,7 +57,7 @@ function App() {
       <Warpper>
         <Carousel autoPlay={true}>
           {carouselPhotos.map((img) => (
-            <GalleryItem key={img.title} src={img.src} alt="" />
+            <GalleryItem key={img.title} src={img.src} alt={img.alt} />
           ))}
         </Carousel>
         <ListWrapper>
@@ -64,6 +72,7 @@ function App() {
             })}
           />
         </ListWrapper>
+        <LastColumn ref={inifiniteRef} />
       </Warpper>
     </Container>
   );
@@ -75,10 +84,14 @@ const Container = styled.div``;
 
 const Warpper = styled.div`
   width: 100%;
-  height: 100vh;
+
   padding: 0 30px;
 `;
 
 const ListWrapper = styled.div`
   margin-top: 20px;
+`;
+
+const LastColumn = styled.div`
+  height: 10px;
 `;

--- a/src/hooks/useIntersect.ts
+++ b/src/hooks/useIntersect.ts
@@ -1,0 +1,35 @@
+import { useEffect, useCallback, useRef } from "react";
+
+type IntersectHandler = (
+  entry: IntersectionObserverEntry,
+  observer: IntersectionObserver
+) => void;
+
+interface Props {
+  onIntersect: IntersectHandler;
+  options?: IntersectionObserverInit;
+}
+
+// 특정 요소가 뷰포트에 진입하거나 교차할 때 onIntersect 콜백을 실행하며, IntersectionObserver를 설정하고 관리하는 역할
+export default function useIntersect({ onIntersect, options }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const callback = useCallback(
+    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) onIntersect(entry, observer);
+      });
+    },
+    [onIntersect]
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref, options, callback]);
+
+  return ref;
+}


### PR DESCRIPTION
## 설명

무한 스크롤 적용
- IntersectionObserver를 통한 무한스크롤 구현
- upsplash API 50회 요청 제한을 조절하기 위해 페이지 초기 랜더링 후 5번 요청시 무한 스크롤 제한

구현 영상 

https://github.com/user-attachments/assets/07f16bec-2541-491d-b0bb-ce66a8b1ee13


## 변경 유형
<!-- 해당 사항을 삭제해주세요. -->



- [x] 새로운 기능(기능을 추가한 논브레이킹 변경)
- [ ] 버그 수정(문제를 수정하는 비파괴 변경)
- [ ] Breaking Change(기존 기능이 예상대로 작동하지 않는 수정 또는 기능)
- [ ] 환경 세팅 추가
- [ ] 스타일 수정
- [ ] 문서 업데이트

## 이슈
